### PR TITLE
tagmapのprojectIDを更新する命令を追加

### DIFF
--- a/try-haxe/src/api/Compiler.hx
+++ b/try-haxe/src/api/Compiler.hx
@@ -402,6 +402,7 @@ class Compiler {
 			if (program.save == "SAVE") {
 				cnx.request("UPDATE project SET tmpPro = \""+program.uid+"\",modified = \""+Date.now().toString()+"\" , projectID = \""+program.uid+"\" WHERE ownerUserID = '"+userID+"' AND tmpPro = '"+tmpID+"';");
 				cnx.request("UPDATE day_ranking SET proID = \""+program.uid+"\" , tmpPro = \""+program.uid+"\" WHERE proID = '"+tmpID+"';");
+                cnx.request("UPDATE tagmap SET projectID = \""+program.uid+"\" WHERE projectID = '"+tmpID+"';");
 			} else {
 				cnx.request("UPDATE project SET tmpPro = \""+program.uid+"\",modified = \""+Date.now().toString()+"\" WHERE ownerUserID = '"+userID+"' AND tmpPro = '"+tmpID+"';");
 				cnx.request("UPDATE day_ranking SET tmpPro = \""+program.uid+"\" WHERE proID = '"+tmpID+"';");


### PR DESCRIPTION
fix #74 

プロジェクトの更新があった際、tagmapのIDの更新を行うように変更
